### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/bot/triggers/commands/__init__.py
+++ b/bot/triggers/commands/__init__.py
@@ -1,7 +1,7 @@
 from ..message_trigger import MessageTrigger
 from .. import utils
 import re
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 
 class Command(MessageTrigger):
@@ -20,9 +20,9 @@ class Command(MessageTrigger):
                     break
                 if msg.content.lower().startswith(prefix):
                     ratio = fuzz.ratio(
-                        msg.content.lower().split()[0], f"{prefix}{name}"
+                        msg.content.lower().split()[0], f"{prefix}{name}", score_cutoff=max_ratio
                     )
-                    max_ratio = ratio if ratio > max_ratio else max_ratio
+                    max_ratio = ratio or max_ratio
             if command:
                 break
 

--- a/bot/triggers/commands/class_management.py
+++ b/bot/triggers/commands/class_management.py
@@ -9,7 +9,7 @@ import ast
 import re
 
 # from fuzzyfinder import fuzzyfinder
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 
 async def fuzzy_search(client, query, max_results):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
 discord.py>=1.2.3
 emoji
-fuzzywuzzy
+rapidfuzz
 googletrans>=2.4.0
 Pillow>=6.1.0
 python-dotenv>=0.10.3
-python-Levenshtein
 requests>=2.22.0
 Wikipedia-API
 wolframalpha


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy